### PR TITLE
 [feat]: add small "copied" popup feature after clicking on "copy CID…

### DIFF
--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -181,20 +181,22 @@ hr {
 
 #tooltip {
   border: 0.2rem solid #cccdcd;
-  border-radius: 0.2rem;
+  border-radius: 5px;
   color: #326d6e;
   background-color: #ffffff;
   display: none;
   position: absolute;
   padding: 0.5rem;
   height: 18px;
-  width: 80px;
-  left: 275px;
-  top: 421px;
+  width: 70px;
+  left: 285px;
+  top: 423px;
   z-index: 5;
 }
 
-#tooltip > strong {
+#tooltip > div:nth-child(1) {
+  font-family: "Open Sans", sans-serif;
+  letter-spacing: 2px;
   font-size: 1rem;
 }
 

--- a/src/css/popup.css
+++ b/src/css/popup.css
@@ -179,6 +179,37 @@ hr {
   margin-bottom: 5px;
 }
 
+#tooltip {
+  border: 0.2rem solid #cccdcd;
+  border-radius: 0.2rem;
+  color: #326d6e;
+  background-color: #ffffff;
+  display: none;
+  position: absolute;
+  padding: 0.5rem;
+  height: 18px;
+  width: 80px;
+  left: 275px;
+  top: 421px;
+  z-index: 5;
+}
+
+#tooltip > strong {
+  font-size: 1rem;
+}
+
+#tooltip-pointer {
+  background-color: #cccdcd;
+  transform: rotate(45deg);
+  position: absolute;
+  display: none;
+  height: 10px;
+  width: 10px;
+  left: 348px;
+  top: 456px;
+  z-index: 2;
+}
+
 #svg-download {
   margin-bottom: 0px;
   margin-left: 15px;

--- a/src/folderUpload.html
+++ b/src/folderUpload.html
@@ -71,6 +71,10 @@
           d="M384 96L384 0h-112c-26.51 0-48 21.49-48 48v288c0 26.51 21.49 48 48 48H464c26.51 0 48-21.49 48-48V128h-95.1C398.4 128 384 113.6 384 96zM416 0v96h96L416 0zM192 352V128h-144c-26.51 0-48 21.49-48 48v288c0 26.51 21.49 48 48 48h192c26.51 0 48-21.49 48-48L288 416h-32C220.7 416 192 387.3 192 352z"
         ></path>
       </svg>
+      <div id="tooltip">
+        <strong>Copied !</strong>
+      </div>
+      <div id="tooltip-pointer"></div>
     </section>
     <section class="center">
       <label for="link" class="output-label"><b>URL: </b></label>

--- a/src/folderUpload.html
+++ b/src/folderUpload.html
@@ -72,7 +72,7 @@
         ></path>
       </svg>
       <div id="tooltip">
-        <strong>Copied !</strong>
+        <div>COPIED</div>
       </div>
       <div id="tooltip-pointer"></div>
     </section>

--- a/src/js/qrcode.js
+++ b/src/js/qrcode.js
@@ -16,6 +16,7 @@ var QR_CODE = new QRCode("qrcode", {
 // web3.storage API token
 const token = process.env.API_TOKEN;
 const client = new Web3Storage({ token });
+let isTooltipVisible = false;
 
 function hideLoader(callback) {
   $(".loader").hide(function () {
@@ -29,6 +30,19 @@ function showLoader() {
   $("section.flex-center > svg").css("aria-disabled", true);
   $("#qrcode img").css("display", "none");
   $(".output-label + div").text("");
+}
+
+function showCopiedTooltip() {
+  if (!isTooltipVisible) {
+    $("#tooltip").css("display", "block");
+    $("#tooltip-pointer").css("display", "block");
+    isTooltipVisible = true;
+    setTimeout(function () {
+      $("#tooltip").css("display", "none");
+      $("#tooltip-pointer").css("display", "none");
+      isTooltipVisible = false;
+    }, 1000);
+  }
 }
 
 function uploadCallback(cid, ipfsLink) {
@@ -45,6 +59,7 @@ function uploadCallback(cid, ipfsLink) {
   $("#svg-cid")
     .off()
     .on("click", function () {
+      showCopiedTooltip();
       navigator.clipboard.writeText(cid);
     });
   // Generate QR code

--- a/src/popup.html
+++ b/src/popup.html
@@ -72,6 +72,10 @@
           d="M384 96L384 0h-112c-26.51 0-48 21.49-48 48v288c0 26.51 21.49 48 48 48H464c26.51 0 48-21.49 48-48V128h-95.1C398.4 128 384 113.6 384 96zM416 0v96h96L416 0zM192 352V128h-144c-26.51 0-48 21.49-48 48v288c0 26.51 21.49 48 48 48h192c26.51 0 48-21.49 48-48L288 416h-32C220.7 416 192 387.3 192 352z"
         ></path>
       </svg>
+      <div id="tooltip">
+        <strong>Copied !</strong>
+      </div>
+      <div id="tooltip-pointer"></div>
     </section>
     <section class="center">
       <label for="link" class="output-label"><b>URI: </b></label>

--- a/src/popup.html
+++ b/src/popup.html
@@ -73,7 +73,7 @@
         ></path>
       </svg>
       <div id="tooltip">
-        <strong>Copied !</strong>
+        <div>COPIED</div>
       </div>
       <div id="tooltip-pointer"></div>
     </section>


### PR DESCRIPTION
The following is a preview of how the "copied" tooltip appears, when the extension is used via the Chrome web browser.
<div align="center">
  <img src="https://user-images.githubusercontent.com/54069350/157922699-ce5d7b6a-ca15-4949-9be1-cf7de6073c28.png">
</div>