### PR TITLE
[fix]: error when upload in cancelled and limit max percentage

### DIFF
--- a/src/js/qrcode.js
+++ b/src/js/qrcode.js
@@ -113,7 +113,7 @@ function getProgressUpdater(files) {
   return (bytes) => {
     uploadedBytes += bytes;
     var percent = totalBytes ? (100 * uploadedBytes) / totalBytes : 100;
-    updateProgress(percent);
+    updateProgress(Math.min(percent, 100));
   };
 }
 

--- a/src/js/qrcode.js
+++ b/src/js/qrcode.js
@@ -164,8 +164,10 @@ function updateQRColor(colorPropName, hexCode = "#000000") {
 
 // Generate decentralized QR code from file
 $("#fileUpload").on("change", async function () {
-  showLoader();
   var files = fileUpload.files;
+  if (files.length === 0) return;
+
+  showLoader();
   var cid = await client.put(files, {
     onStoredChunk: getProgressUpdater(files),
     wrapWithDirectory: false,
@@ -179,8 +181,10 @@ QR_CODE_DISPLAY.clear();
 
 // Generate decentralized QR code from folder
 $("#folderUpload").on("change", async function () {
-  showLoader();
   var files = folderUpload.files;
+  if (files.length === 0) return;
+
+  showLoader();
   var cid = await client.put(files, {
     onStoredChunk: getProgressUpdater(files),
   });


### PR DESCRIPTION
## Related Issue (if any)

<!-- Info about the related issue -->

Closes: #33 

### Describe the add-ons or changes you've made

Modified the upload functions to not execute when files.length is 0.
Also a small fix on the percentage loader to always be smaller than 100% (it used to break for very small files, e.g. an empty folder)

## Type of change

<!-- What sort of change have you made: -->
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The same steps mentioned on #33 

1. Click on "Upload" button
2. Select a file and confirm upload
3. Click on "Upload" again
4. Cancel the file upload

## Checklist:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the "contribution guidelines" of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly wherever it was hard to understand.
- [x] My changes generate no new warnings.
- [ ] Any dependent changes have been merged and published in downstream modules.
